### PR TITLE
Make Mangaflix more readable

### DIFF
--- a/ManganatoFlix/mangaflix
+++ b/ManganatoFlix/mangaflix
@@ -1,21 +1,73 @@
 #!/bin/sh
-QUERY=$(printf "%s" "$*" | sed 's/ /\_/g')
-MANGA=$(echo $QUERY | grep -Eo "[a-zA-Z_+.\_]*" | sed s'/.$//')
-CHAPTER=$(echo $QUERY | grep -Eo "[0-9.]*") 
-# this line gets the user input, and splits it into the manga name and the chapter number
 
-LINK_OF_MANGA_HOME=$(curl -s "https://manganato.com/search/story/$MANGA" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' | pup 'div.panel-search-story' | grep -Eo "https\:\\/\/readmanganato.com\/manga\-[a-zA-Z0-9?%-' '=.+;-]*" | head -n 1)
-LINK_OF_MANGA_IMAGES=$(curl -s "$LINK_OF_MANGA_HOME" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' | pup 'ul.row-content-chapter li.a-h a.chapter-name' | grep -Eo "$LINK_OF_MANGA_HOME\/chapter\-$CHAPTER" | head -n 1)
-MANGA_NAME=$(curl -s "$LINK_OF_MANGA_HOME" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' | pup 'div.story-info-right h1 text{}' | sed 's/ /\_/g') 
+# get the user input, and split it into the manga name and the chapter number
+QUERY=`printf "%s" "$*" | sed 's/ /\_/g'`
+for CHAPTER in "$@"; do :; done
+MANGA=${QUERY%_$CHAPTER}
+
+LINK_OF_MANGA_HOME=`
+curl -s "https://manganato.com/search/story/$MANGA" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' \
+  | pup 'div.panel-search-story' \
+  | grep -Eo "https\:\\/\/readmanganato.com\/manga\-[a-zA-Z0-9?%-' '=.+;-]*" \
+  | head -n 1 \
+  `
+
+LINK_OF_MANGA_IMAGES=`
+curl -s "$LINK_OF_MANGA_HOME" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' \
+  | pup 'ul.row-content-chapter li.a-h a.chapter-name' \
+  | grep -Eo "$LINK_OF_MANGA_HOME\/chapter\-$CHAPTER" \
+  | head -n 1 \
+  `
+
 # This line gets the link of the manga home page, manga images link and also the name of the anime
+MANGA_NAME=`
+curl -s "$LINK_OF_MANGA_HOME" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' \
+  | pup 'div.story-info-right h1 text{}' \
+  | sed 's/ /\_/g' \
+  `
 
-IMG_BASE_URL=$(curl -s "$LINK_OF_MANGA_IMAGES" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' | pup 'div.container-chapter-reader img' | grep -Eo "https\:\\/\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/" | head -n 1)
-NUM_OF_MANGA_IMAGES=$(curl -s "$LINK_OF_MANGA_IMAGES" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' | pup 'div.container-chapter-reader img' | grep -Eo "https\:\\/\/[a-zA-Z0-9?%-' '=.+;-\/_]*" | wc -l) 
+IMG_BASE_URL=`
+curl -s "$LINK_OF_MANGA_IMAGES" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' \
+  | pup 'div.container-chapter-reader img' \
+  | grep -Eo "https\:\\/\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/[a-zA-Z0-9?%-' '=.+;-_]*\/" \
+  | head -n 1 \
+  `
+
+NUM_OF_MANGA_IMAGES=`
+curl -s "$LINK_OF_MANGA_IMAGES" -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; rv:91.0) Gecko/20100101 Firefox/91.0' \
+  | pup 'div.container-chapter-reader img' \
+  | grep -Eo "https\:\\/\/[a-zA-Z0-9?%-' '=.+;-\/_]*" \
+  | wc -l \
+  `
 # This line gets the image base url and the number of manga images for the for loop
 
 DOWNLOAD_DIR="$HOME/Documents/torrent/manga/"
-IMAGE_DOWNLOAD=$(for ((i = 1; i <=$NUM_OF_MANGA_IMAGES; i++)) ; do $(curl -s "$IMG_BASE_URL$i.jpg" --output "$DOWNLOAD_DIR$MANGA_NAME$i.jpg" -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:97.0) Gecko/20100101 LibreWolf/97.0' -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US,en;q=0.5' -H 'Accept-Encoding: gzip, deflate, br' -H 'Referer: https://readmanganato.com/' -H 'DNT: 1' -H 'Connection: keep-alive' -H 'Upgrade-Insecure-Requests: 1' -H 'Sec-Fetch-Dest: document' -H 'Sec-Fetch-Mode: navigate' -H 'Sec-Fetch-Site: cross-site' -H 'Sec-Fetch-User: ?1' -H 'If-Modified-Since: Sun, 20 Feb 2022 17:11:30 GMT' -H 'If-None-Match: "62127642-21b3d"' -H 'Cache-Control: max-age=0' -H 'TE: trailers') ; done)
-CONVERT_IMAGES_TO_PDF=$(convert $(/usr/bin/ls -v $DOWNLOAD_DIR$MANGA_NAME*.jpg) "$DOWNLOAD_DIR$MANGA_NAME-$CHAPTER.pdf" )
-DELETE_IMAGES=$(rm $DOWNLOAD_DIR$MANGA_NAME*.jpg)
-OPEN_PDF_MANGA=$(zathura $DOWNLOAD_DIR$MANGA_NAME-$CHAPTER.pdf) 
-# this line downlaods the images compiles it into pdf and opens it. there is a mv to prevent gio error
+# IMAGE DOWNLOAD
+for ((i = 1; i <=$NUM_OF_MANGA_IMAGES; i++)); do
+  curl -s "$IMG_BASE_URL$i.jpg" --output "$DOWNLOAD_DIR$MANGA_NAME$i.jpg" \
+    -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:97.0) Gecko/20100101 LibreWolf/97.0' \
+    -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br' \
+    -H 'Referer: https://readmanganato.com/' \
+    -H 'DNT: 1' \
+    -H 'Connection: keep-alive' \
+    -H 'Upgrade-Insecure-Requests: 1' \
+    -H 'Sec-Fetch-Dest: document' \
+    -H 'Sec-Fetch-Mode: navigate' \
+    -H 'Sec-Fetch-Site: cross-site' \
+    -H 'Sec-Fetch-User: ?1' \
+    -H 'If-Modified-Since: Sun, 20 Feb 2022 17:11:30 GMT' \
+    -H 'If-None-Match: "62127642-21b3d"' \
+    -H 'Cache-Control: max-age=0' \
+    -H 'TE: trailers' \
+;done
+
+# CONVERT IMAGES TO PDF
+convert $(/usr/bin/ls -v $DOWNLOAD_DIR$MANGA_NAME*.jpg) "$DOWNLOAD_DIR$MANGA_NAME-$CHAPTER.pdf"
+
+# DELETE IMAGES
+rm $DOWNLOAD_DIR$MANGA_NAME*.jpg
+
+# OPEN PDF MANGA
+zathura $DOWNLOAD_DIR$MANGA_NAME-$CHAPTER.pdf


### PR DESCRIPTION
added a few breaks on the longer lines.
The original script used the pattern 
```bash
LABEL=$(action)
```
to perform many actions. I find this hard to parse when compared to 
```sh
# LABEL
action
```
which also avoids spawning a whole new shell for each command.

I also replaced instances of `$(...)` to spawn subcommands with ``` `...` ```, which will work on `dash` and other posix compatible shells.

If your worry in writing this was minimalism, please note that this version is only 6 bytes larger than the original (2913 vs 2906)